### PR TITLE
fix: add missing kernel setup

### DIFF
--- a/21-write-config-and-cmdline-txt.sh
+++ b/21-write-config-and-cmdline-txt.sh
@@ -49,3 +49,57 @@ EOF
 cat << EOF > "${_MP}/boot/cmdline.txt"
 root=/dev/mmcblk0p2 rootfstype=ext4 rw rootwait loglevel=3 cpufreq.default_governor=schedutil
 EOF
+
+# Enable NetworkManager and SSH during build
+echo "Enabling NetworkManager and SSH..."
+if chroot "${_MP}" systemctl enable NetworkManager; then
+    echo "NetworkManager enabled successfully"
+else
+    echo "Warning: Failed to enable NetworkManager"
+fi
+
+if chroot "${_MP}" systemctl enable sshd; then
+    echo "SSH enabled successfully"
+else
+    echo "Warning: Failed to enable SSH"
+fi
+
+# Create a simple keyring init script for first use
+cat > "${_MP}/usr/local/bin/init-keyring.sh" << 'EOF'
+#!/bin/bash
+if [ ! -f /var/lib/keyring-initialized ]; then
+    echo "Initializing package signing keys (this may take a few minutes)..."
+    
+    # Check if running as root or with sudo
+    if [ "$EUID" -ne 0 ]; then
+        echo "This script needs to run as root. Use: sudo init-keyring.sh"
+        exit 1
+    fi
+    
+    if pacman-key --init && pacman-key --populate archlinuxarm; then
+        touch /var/lib/keyring-initialized
+        echo "✓ Keyring initialized successfully!"
+        echo "You can now install packages with pacman."
+    else
+        echo "✗ Failed to initialize keyring. Check your internet connection."
+        exit 1
+    fi
+else
+    echo "Keyring already initialized."
+fi
+EOF
+chmod +x "${_MP}/usr/local/bin/init-keyring.sh"
+
+# Add helpful message to MOTD
+cat >> "${_MP}/etc/motd" << 'EOF'
+
+Welcome to uConsole Arch Linux!
+
+First-time setup:
+1. Connect to WiFi: nmcli dev wifi connect "SSID" password "PASSWORD"
+   Or use the text UI: nmtui
+2. Initialize package keyring: sudo init-keyring.sh
+3. Update system: sudo pacman -Syu
+
+For help: https://wiki.archlinux.org/
+EOF

--- a/22-setup-kernel-and-initramfs.sh
+++ b/22-setup-kernel-and-initramfs.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# This script sets up kernel files and generates initramfs
+
+source ./envs.sh
+check_var_non_empty WORKING_DIR IMAGE_MOUNT_POINT
+
+_MP=${WORKING_DIR%/}/${IMAGE_MOUNT_POINT%/}
+_MP_ABS=$(readlink -f "${_MP}")
+
+echo "Setting up kernel and initramfs..."
+
+# Create the missing mkinitcpio preset
+cat > "${_MP}/etc/mkinitcpio.d/linux-uconsole-rpi64.preset" << 'EOF'
+# mkinitcpio preset file for the linux-uconsole-rpi64 package
+
+ALL_config="/etc/mkinitcpio.conf"
+ALL_kver="/boot/vmlinuz-linux-uconsole-rpi64"
+
+PRESETS=('default')
+
+default_image="/boot/initramfs-linux-uconsole-rpi64.img"
+EOF
+
+# Find the kernel version
+KERNEL_VERSION=$(ls "${_MP}/usr/lib/modules/" | head -1)
+echo "Found kernel version: $KERNEL_VERSION"
+
+# Copy kernel from modules directory to /boot in rootfs
+if [ -f "${_MP}/usr/lib/modules/${KERNEL_VERSION}/vmlinuz" ]; then
+    cp "${_MP}/usr/lib/modules/${KERNEL_VERSION}/vmlinuz" "${_MP}/boot/vmlinuz-linux-uconsole-rpi64"
+    echo "Copied kernel to rootfs /boot"
+else
+    echo "ERROR: Kernel file not found"
+    exit 1
+fi
+
+# Set up proper chroot environment and generate initramfs
+echo "Generating initramfs..."
+
+# Mount necessary filesystems for chroot
+mount --bind /dev "${_MP}/dev"
+mount --bind /proc "${_MP}/proc" 
+mount --bind /sys "${_MP}/sys"
+
+# Generate initramfs in chroot
+chroot "${_MP}" /bin/bash -c "
+    export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    mkinitcpio -k ${KERNEL_VERSION} -g /boot/initramfs-linux-uconsole-rpi64.img
+"
+
+# Clean up bind mounts
+umount "${_MP}/sys" || true
+umount "${_MP}/proc" || true  
+umount "${_MP}/dev" || true
+
+# Verify initramfs was created
+if [ ! -f "${_MP}/boot/initramfs-linux-uconsole-rpi64.img" ]; then
+    echo "ERROR: initramfs generation failed"
+    exit 1
+fi
+
+echo "Kernel and initramfs setup completed successfully"
+echo "Kernel: $(ls -lh ${_MP}/boot/vmlinuz-linux-uconsole-rpi64)"
+echo "Initramfs: $(ls -lh ${_MP}/boot/initramfs-linux-uconsole-rpi64.img)"

--- a/README.md
+++ b/README.md
@@ -1,32 +1,184 @@
-# Image scripts
+# uConsole Arch Linux Image Builder
 
-Here is a set of scripts to create a archlinux image for uConsole(CM3/CM4/CM4S) or whatever.
+A set of scripts to create a ready-to-use Arch Linux ARM image for the Clockwork Pi uConsole (CM3/CM4/CM4S).
 
-## How to use the scripts
+## Features
 
-`envs.sh` is the global config file. Edit the envs as you wish, and run the scripts in ascending order.
-Or, for convenience, run `run-all.sh` once.
+- **Universal compatibility**: Works with CM3, CM4, and CM4S modules
+- **Complete WiFi support**: Includes multiple WiFi management tools (NetworkManager, iwd, wpa_supplicant)
+- **Pre-configured display**: Display settings optimized for uConsole screen
+- **Automatic first-boot setup**: NetworkManager and SSH enabled by default
+- **Comprehensive package set**: Includes essential networking, development, and troubleshooting tools
 
-No script needs user interaction. But be careful, **scripts require superuser privilege**.
+## Requirements
 
-To install requirements on ArchLinux:
+### Build System
+- Arch Linux host system (or compatible ARM build environment)
+- Root/sudo access
+- At least 8GB free disk space
+- Internet connection for package downloads
 
+### Install build dependencies:
 ```bash
-pacman -Sy --needed qemu-user-static qemu-user-static-binfmt arch-install-scripts parted dosfstools e2fsprogs
+sudo pacman -Sy --needed qemu-user-static qemu-user-static-binfmt arch-install-scripts parted dosfstools e2fsprogs
 ```
 
-## About default configuration
+### Target Hardware  
+- uConsole with CM3, CM4, or CM4S module
+- MicroSD card (8GB minimum, 32GB+ recommended)
 
-Read the `env.sh` first. It's not long.
+## Quick Start
 
-The default configuration is for CM3(and possibly CM4) with the necessary additions to enable the wireless module.
+1. **Clone and configure**:
+   ```bash
+   git clone https://github.com/PotatoMania/uconsole-cm3-arch-image-builder.git
+   cd uconsole-cm3-arch-image-builder
+   # Edit envs.sh to customize your build (optional)
+   ```
 
-The default privileged user's name and password are both `ucon`.
+2. **Build the image**:
+   ```bash
+   sudo ./run-all.sh
+   ```
 
-It may be necessary to setup locales, package repository mirrors, etc. after flashing the image.
+3. **Flash to SD card**:
+   ```bash
+   # Find your SD card device
+   lsblk
+   
+   # Flash the image (replace sdX with your actual device)
+   sudo dd if=/workspace/image-build/uconsole_arch.img of=/dev/sdX bs=4M status=progress
+   sudo sync
+   ```
 
-The network can be managed via `nmcli`, given Network Manager enabled via `systemctl enable --now NetworkManager`.
+4. **Boot and setup**:
+   - Insert SD card into uConsole and power on
+   - Connect to WiFi: `nmcli dev wifi connect "YourSSID" password "YourPassword"`
+   - Initialize package signing: `sudo init-keyring.sh`
+   - Update system: `sudo pacman -Syu`
 
-`vim` is installed as a preloaded text editor.
+## Configuration
 
-The partition must be resized to utilize all space on uSD card.
+### Default Settings
+- **User account**: `ucon` / `ucon` (configured in `envs.sh`)
+- **Image size**: ~4GB (configurable in `envs.sh`)
+- **Swap**: 1GB swapfile
+- **Editors**: vim and nano pre-installed
+- **Services**: NetworkManager and SSH enabled by default
+
+### Customization
+Edit `envs.sh` before building to customize:
+- Image size and partitioning
+- User credentials
+- Package selection
+- Build location
+
+## What's Included
+
+### System Packages
+- Base Arch Linux ARM system
+- Custom uConsole kernel with display drivers
+- WiFi firmware and regulatory database
+- Essential system utilities
+
+### Networking
+- NetworkManager (primary)
+- iwd (Intel wireless daemon)
+- wpa_supplicant (traditional WiFi)
+- dhcpcd (DHCP client)
+- SSH server (enabled by default)
+
+### Development & Troubleshooting
+- vim, nano (text editors)
+- htop (process monitor)
+- wireless tools (iw, iwconfig, etc.)
+- network utilities (ping, wget, curl)
+- hardware detection tools (lshw, lsusb, lspci)
+
+## Post-Installation
+
+### First Boot
+The system automatically:
+- Starts NetworkManager for WiFi connectivity
+- Enables SSH for remote access
+- Displays helpful setup instructions
+
+### Initial Setup
+1. **Connect to WiFi**:
+   ```bash
+   # Command line
+   nmcli dev wifi connect "YourSSID" password "YourPassword"
+   
+   # Or use text UI
+   nmtui
+   ```
+
+2. **Initialize package manager**:
+   ```bash
+   sudo init-keyring.sh
+   ```
+
+3. **Update system**:
+   ```bash
+   sudo pacman -Syu
+   ```
+
+4. **Optional: Expand filesystem** (if needed):
+   ```bash
+   sudo resize2fs /dev/mmcblk0p2
+   ```
+
+### WiFi Troubleshooting
+If WiFi doesn't work:
+```bash
+# Check WiFi interface
+ip link show
+
+# Scan for networks
+nmcli dev wifi list
+
+# Check driver status
+dmesg | grep -i wifi
+
+# Manual interface up
+sudo ip link set wlan0 up
+```
+
+## Verification (Optional but Recommended)
+
+Verify your flash was successful:
+```bash
+# Compare checksums of first 1GB
+sudo dd if=/dev/sdX bs=4M count=256 | md5sum
+sudo dd if=/workspace/image-build/uconsole_arch.img bs=4M count=256 | md5sum
+# These should match
+```
+
+## Build Process Details
+
+The build process runs these steps automatically:
+1. Create empty disk image
+2. Partition the image (boot + root)
+3. Format and mount partitions  
+4. Install base system with pacstrap
+5. Install custom kernel and WiFi firmware
+6. Generate initramfs and copy kernel files
+7. Configure boot settings and services
+8. Create user account
+9. Compress final image
+
+## Troubleshooting
+
+### Build Issues
+- **Permission denied**: Ensure you're running with `sudo`
+- **Package download fails**: Check internet connection and mirrors
+- **Out of space**: Increase `IMAGE_SIZE` in `envs.sh`
+
+### Boot Issues  
+- **Black screen**: Check SD card connection and power
+- **Kernel panic**: Verify image was flashed completely
+- **No WiFi**: Run `sudo init-keyring.sh` and update system
+
+### Network Issues
+- **Can't connect to WiFi**: Try `nmtui` for interactive setup
+- **No internet after WiFi connects**: Check DNS with `nslookup google.com`

--- a/envs.sh
+++ b/envs.sh
@@ -6,10 +6,10 @@
 WORKING_DIR="/workspace/image-build"
 
 # image file name
-IMAGE_NAME="test-image.img"
+IMAGE_NAME="uconsole_arch.img"
 
-# full image size, in MiB
-IMAGE_SIZE=4096
+# full image size, in MiB (using ~30GB of the 32GB card, leaving some overhead)
+IMAGE_SIZE=4096 
 
 # boot partition size, in MiB
 BOOT_SIZE=300
@@ -22,14 +22,14 @@ SWAP_SIZE=1024
 # or read from environment
 # can be online resource
 # currently only support for pacstrap and http source are implemented
-#ROOTFS_ARCHIVE=http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz
+# ROOTFS_ARCHIVE=http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz
 
 # Pacstrap bootstrapping settings
 PACSTRAP_PACMAN_CONFIG_FILE=resources/arch-stage0-pacman.conf
 # For China mainland users
 #PACSTRAP_PACMAN_CONFIG_FILE=resources/arch-stage0-cn-pacman.conf
 
-# first privileged user's name and password
+# first privileged user's name and password (matching the standard uConsole image)
 NEW_USER_NAME=ucon
 NEW_USER_PASSWORD=ucon
 
@@ -43,10 +43,30 @@ PACSTRAP_EXTRA_PACKAGES=(
 	archlinuxarm-keyring
 	raspberrypi-bootloader
 	linux-firmware
+	firmware-raspberrypi
 	wireless-regdb
 	networkmanager
+	iwd
+	wpa_supplicant
+	dhcpcd
 	vim
+	nano
 	sudo
+	openssh
+	iw
+	wireless_tools
+	net-tools
+	iputils
+	man-db
+	man-pages
+	dnsutils
+	wget
+	curl
+	htop
+	lshw
+	usbutils
+	pciutils
+	pacman-contrib
 )
 
 # These are custom packages, located in pkgs

--- a/run-all.sh
+++ b/run-all.sh
@@ -10,6 +10,7 @@ set -e
 ./20-install-custom-packages.sh
 ./20-write-fstab.sh
 ./21-write-config-and-cmdline-txt.sh
+./22-setup-kernel-and-initramfs.sh
 ./25-create-user.sh
 ./90-unmount-unload-partitions.sh
 ./95-compress-image-file.sh


### PR DESCRIPTION
The build process was failing to generate the initramfs and not copying kernel files to the boot partition. This was resulting in a black screen on startup. The build would complete without errors, but the resulting image was unbootable.
Also added some more default packages to help with WiFi troubleshooting and updated readme with more info and instructions.